### PR TITLE
clarify code & improve UX

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -44,17 +44,17 @@ check_next_problem <- function(track_id = "r") {
 #' Fetches the files for a problem via the Exercism API and writes them into
 #' a new problem folder in the Exercism directory
 #'
-#' @param track_id a normalized, url-safe identifier for a language track.
-#'  e.g. r, python, javascript etc
 #' @param slug a normalized, url-safe identifier for a problem
 #'  e.g. "hello-world"
+#' @param track_id a normalized, url-safe identifier for a language track.
+#'  e.g. r, python, javascript etc
 #' @param force logical, indicating whether existing problem files should be
 #'  overwritten
 #'
 #' @return Prints confirmation message upon success
 #'
 #' @export
-fetch_problem <- function(track_id = "r", slug, force = FALSE) {
+fetch_problem <- function(slug, track_id = "r", force = FALSE) {
 
   path <- sprintf("tracks/%s/%s", track_id, slug)
   # Could also use "/v2/exercises/[track_id]/[slug]"
@@ -148,15 +148,15 @@ fetch_next <- function(track_id = "r", skip = FALSE, force = FALSE) {
 #'
 #' Marks a problem as 'skipped' via the Exercism API
 #'
-#' @param track_id a normalized, url-safe identifier for a language track.
-#'  e.g. r, python, javascript etc
 #' @param slug a normalized, url-safe identifier for a problem
 #'  e.g. "hello-world"
+#' @param track_id a normalized, url-safe identifier for a language track.
+#'  e.g. r, python, javascript etc
 #'
 #' @return Prints confirmation message upon success
 #'
 #' @export
-skip_problem <- function(track_id = "r", slug) {
+skip_problem <- function(slug, track_id = "r") {
 
   path <- sprintf("api/v1/iterations/%s/%s/skip", track_id, slug)
 

--- a/R/api.R
+++ b/R/api.R
@@ -20,8 +20,8 @@ check_next_problem <- function(track_id = "r") {
     query = list(key = get_api_key())
   )
 
-  resp <- httr::GET(url, ua)
 
+  resp <- httr::GET(url, config = user_agent)
   check_api_response(resp)
 
   x <- httr::content(resp)$problems[[1]]
@@ -61,7 +61,7 @@ fetch_problem <- function(track_id = "r", slug, force = FALSE) {
 
   url <- httr::modify_url(root_x, path = path)
 
-  resp <- httr::GET(url, ua)
+  resp <- httr::GET(url, user_agent)
 
   check_api_response(resp)
 
@@ -125,7 +125,7 @@ fetch_next <- function(track_id = "r", skip = FALSE, force = FALSE) {
     query = list(key = get_api_key())
   )
 
-  resp <- httr::GET(url, ua)
+  resp <- httr::GET(url, user_agent)
 
   check_api_response(resp)
 
@@ -162,7 +162,7 @@ skip_problem <- function(track_id = "r", slug) {
 
   url <- httr::modify_url(root, path = path, query = list(key = get_api_key()))
 
-  resp <- httr::POST(url, ua)
+  resp <- httr::POST(url, user_agent)
 
   check_api_response(resp)
 
@@ -186,7 +186,7 @@ track_status <- function(track_id = "r") {
 
   url <- httr::modify_url(root, path = path, query = list(key = get_api_key()))
 
-  resp <- httr::GET(url, ua)
+  resp <- httr::GET(url, user_agent)
 
   check_api_response(resp)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,4 @@
-# Set user agent
-ua <- httr::user_agent("http://github.com/jonmcalder/exercism")
+user_agent <- httr::user_agent("http://github.com/jonmcalder/exercism")
 
 # Set root URL for exercism API
 root <- "http://exercism.io"

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -47,10 +47,12 @@ get_existing_config <- function() {
     }
 
     if (!nzchar(key)) {
-      message("Exercism API key not set. Please run set_api_key().")
+      message("Exercism API key not set. Please log into exercism.io/account/key,
+              copy the key and run set_api_key().")
     }
     if (!nzchar(path)) {
-      message("Exercism path not set. Please run set_exercism_path().")
+      message("Exercism path not set. Please run set_exercism_path(\"...\") with
+              a directory path.")
     }
 
   }


### PR DESCRIPTION
With `allow omission of slug parameter` it is now possible to use `fetch_problem("slug")`. Before, it would interpret `slug` as a change to the `track_ID = "r"` default.